### PR TITLE
Add VS Code dev container for nodeJS & yarn environment.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:16-bullseye
+#RUN npm install -g yarn

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "node"
+}


### PR DESCRIPTION
# Description

Added a VS Code dev container for nodeJs and yarn. If using VS Code a developer doesn't have to install or configure nodeJS & yarn. Just launch VS Code and click to open in container.

![vs-code](https://ipfs.io/ipfs/QmbGgBLwFU4T6SnjPyvnbFmTSdiFckHgBoV2x5Q1qVQDUL)